### PR TITLE
Clarify README feed markers

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -1,0 +1,30 @@
+name: Update README with latest posts
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Update README
+        run: npm run update:readme
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'chore: update README with latest posts'
+          file_pattern: README.md

--- a/README.md
+++ b/README.md
@@ -42,6 +42,22 @@
 
 정리하면, 고난이도 UX를 도구로 풀어내는 빌더형 프론트엔드로서 입력/모션 같은 저수준 상호작용에 강하고, 이를 팀 생산성과 브랜딩으로 확장합니다.
 
+## 📰 새로 올라온 글
+
+### Portfolio · GitHub Pages
+> 💡 `<!--START_GITHUB_PAGES-->` / `<!--END_GITHUB_PAGES-->` 마커는 GitHub Actions가 최신 글 목록을 주입하기 위한 자동화 구간입니다.
+<!--START_GITHUB_PAGES-->
+- (자동 갱신 준비 중입니다.)
+<!--END_GITHUB_PAGES-->
+
+### Velog
+> 💡 `<!--START_VELOG-->` / `<!--END_VELOG-->` 마커 역시 Velog 최신 글을 자동으로 삽입하기 위한 영역입니다.
+<!--START_VELOG-->
+- (자동 갱신 준비 중입니다.)
+<!--END_VELOG-->
+
+> 위 목록은 GitHub Actions로 매일 자동 갱신됩니다.
+
 ## 📌 대표 레포 & 근거 링크
 - [virtual-keyboard](https://github.com/uiwwsw/virtual-keyboard) — 한국어 composition 이슈 해결, 커스텀 키보드/입력, 모바일 네이티브 키보드 차단, React Provider 패턴, 데모 제공.
 - [react-query-helper](https://github.com/uiwwsw/react-query-helper) — API→훅/옵션 자동 생성, watch/generate 모드, 템플릿/Prettier 통합, Bun/NPM 설치 가이드.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "uiwwsw-profile-automation",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "uiwwsw-profile-automation",
+      "version": "1.0.0",
+      "private": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "uiwwsw-profile-automation",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "update:readme": "node scripts/update-readme.js"
+  }
+}

--- a/scripts/update-readme.js
+++ b/scripts/update-readme.js
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const README_PATH = path.join(__dirname, '..', 'README.md');
+
+const feeds = [
+  {
+    name: 'GitHub Pages',
+    startMarker: '<!--START_GITHUB_PAGES-->',
+    endMarker: '<!--END_GITHUB_PAGES-->',
+    url: 'https://uiwwsw.github.io/feed.xml',
+    maxItems: 5,
+  },
+  {
+    name: 'Velog',
+    startMarker: '<!--START_VELOG-->',
+    endMarker: '<!--END_VELOG-->',
+    url: 'https://v2.velog.io/rss/uiwwsw',
+    maxItems: 5,
+  },
+];
+
+const dateFormatter = new Intl.DateTimeFormat('ko-KR', {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+
+async function fetchFeed(feedConfig) {
+  const response = await fetch(feedConfig.url, {
+    headers: {
+      'User-Agent': 'uiwwsw-readme-bot/1.0 (+https://github.com/uiwwsw)',
+      Accept: 'application/rss+xml, application/atom+xml; charset=utf-8',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`${feedConfig.name} 피드를 불러오지 못했습니다. status=${response.status}`);
+  }
+
+  return response.text();
+}
+
+function stripCdata(value = '') {
+  return value.replace(/<!\[CDATA\[(.*?)\]\]>/gis, '$1');
+}
+
+function decodeEntities(value = '') {
+  return stripCdata(value)
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#x27;/g, "'")
+    .trim();
+}
+
+function extractTagValue(block, tag) {
+  const regex = new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`, 'i');
+  const match = block.match(regex);
+  return match ? decodeEntities(match[1]) : '';
+}
+
+function extractLink(block) {
+  const linkMatch = block.match(/<link[^>]*href="([^"]+)"[^>]*>/i);
+  if (linkMatch) {
+    return linkMatch[1];
+  }
+
+  const alternateMatch = block.match(/<link[^>]*rel="alternate"[^>]*href="([^"]+)"[^>]*>/i);
+  if (alternateMatch) {
+    return alternateMatch[1];
+  }
+
+  const directMatch = extractTagValue(block, 'link');
+  if (directMatch) {
+    return directMatch;
+  }
+
+  const guidMatch = extractTagValue(block, 'guid');
+  return guidMatch;
+}
+
+function parseFeedContent(xml) {
+  const rssItems = [...xml.matchAll(/<item>([\s\S]*?)<\/item>/gi)];
+  const atomEntries = [...xml.matchAll(/<entry>([\s\S]*?)<\/entry>/gi)];
+  const blocks = rssItems.length ? rssItems : atomEntries;
+
+  return blocks.map((match) => {
+    const block = match[1];
+    const title = extractTagValue(block, 'title') || '제목 없는 게시글';
+    const link = extractLink(block);
+    const pubDate = extractTagValue(block, 'updated') || extractTagValue(block, 'pubDate');
+    const isoDate = pubDate ? new Date(pubDate).toISOString() : null;
+
+    return { title, link, isoDate };
+  });
+}
+
+function formatFeedItems(items, maxItems) {
+  return items
+    .filter((item) => item && item.title)
+    .slice(0, maxItems)
+    .map((item) => {
+      const formattedDate = item.isoDate ? dateFormatter.format(new Date(item.isoDate)) : null;
+      const dateSuffix = formattedDate ? ` _( ${formattedDate} )_` : '';
+      if (item.link) {
+        return `- [${item.title}](${item.link})${dateSuffix}`;
+      }
+      return `- ${item.title}${dateSuffix}`;
+    })
+    .join('\n');
+}
+
+function extractSection(readmeContent, startMarker, endMarker) {
+  const startIndex = readmeContent.indexOf(startMarker);
+  const endIndex = readmeContent.indexOf(endMarker);
+
+  if (startIndex === -1 || endIndex === -1) {
+    throw new Error(`README에 ${startMarker} 또는 ${endMarker} 구간이 없습니다.`);
+  }
+
+  const sectionStart = startIndex + startMarker.length;
+  const currentContent = readmeContent
+    .slice(sectionStart, endIndex)
+    .replace(/^\n+|\n+$/g, '');
+
+  return {
+    startIndex,
+    endIndex,
+    currentContent,
+  };
+}
+
+function replaceSection(readmeContent, startMarker, endMarker, newSectionContent) {
+  const { startIndex, endIndex } = extractSection(readmeContent, startMarker, endMarker);
+  const before = readmeContent.slice(0, startIndex + startMarker.length);
+  const after = readmeContent.slice(endIndex);
+  return `${before}\n${newSectionContent}\n${after}`;
+}
+
+async function main() {
+  let readme = fs.readFileSync(README_PATH, 'utf8');
+  let hasChanges = false;
+
+  for (const feedConfig of feeds) {
+    const { currentContent } = extractSection(readme, feedConfig.startMarker, feedConfig.endMarker);
+    try {
+      const xml = await fetchFeed(feedConfig);
+      const items = parseFeedContent(xml);
+      const formatted = formatFeedItems(items, feedConfig.maxItems);
+
+      if (!formatted) {
+        console.log(`[info] ${feedConfig.name} 피드에서 표시할 항목이 없어 기존 섹션을 유지합니다.`);
+        continue;
+      }
+
+      const updated = replaceSection(readme, feedConfig.startMarker, feedConfig.endMarker, formatted);
+      if (updated !== readme) {
+        hasChanges = true;
+        readme = updated;
+      }
+    } catch (error) {
+      console.warn(`\n[warn] ${feedConfig.name} 섹션 갱신에 실패했습니다: ${error.message}`);
+      if (!currentContent.trim()) {
+        const fallback = '- (데이터를 불러오지 못했습니다.)';
+        const updated = replaceSection(readme, feedConfig.startMarker, feedConfig.endMarker, fallback);
+        if (updated !== readme) {
+          hasChanges = true;
+          readme = updated;
+        }
+      } else {
+        console.log(`[info] ${feedConfig.name} 섹션을 기존 내용으로 유지합니다.`);
+      }
+    }
+  }
+
+  if (hasChanges) {
+    fs.writeFileSync(README_PATH, readme);
+    console.log('README가 최신 피드로 갱신되었습니다.');
+  } else {
+    console.log('변경 사항이 없어 README를 수정하지 않았습니다.');
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- explain in the README that the GitHub Pages and Velog sections are auto-populated by the scheduled action
- reassure readers that the HTML comments are automation markers so they should stay in place

## Testing
- `node scripts/update-readme.js`


------
https://chatgpt.com/codex/tasks/task_e_6902fe037504833183d8b20acd5b6e7e