### PR TITLE
Improve README feed refresh reliability

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   update-readme:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- try multiple feed endpoints with timeouts when updating the README and sort fetched entries by publish date
- log per-endpoint failures and keep placeholders only when every request fails
- grant the workflow explicit contents: write permission so scheduled runs can commit README updates

## Testing
- npm run update:readme *(fails in this environment: fetch failed because external network access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_69030073a2f483318357dd6cced777a0