### PR TITLE
Improve feed fetch error diagnostics

### DIFF
--- a/scripts/update-readme.js
+++ b/scripts/update-readme.js
@@ -63,7 +63,11 @@ async function fetchFeed(feedConfig) {
       return response.text();
     } catch (error) {
       lastError = error;
-      console.warn(`  ↪️  ${feedConfig.name} 피드 ${url} 요청 실패: ${error.message}`);
+      const detail =
+        error && typeof error === 'object'
+          ? [error.message, error.code, error.cause && error.cause.code].filter(Boolean).join(' ')
+          : String(error);
+      console.warn(`  ↪️  ${feedConfig.name} 피드 ${url} 요청 실패: ${detail}`);
     }
     clearTimeout(timeoutId);
   }


### PR DESCRIPTION
## Summary
- include additional diagnostic details when feed requests fail so GitHub Actions logs expose network error codes

## Testing
- npm run update:readme

------
https://chatgpt.com/codex/tasks/task_e_69030bdfd5b08331aaedf90461178196