### PR TITLE
Fix README feed updater to use comment markers correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@
 ### Portfolio · GitHub Pages
 > 💡 `<!--START_GITHUB_PAGES-->` / `<!--END_GITHUB_PAGES-->` 마커는 GitHub Actions가 최신 글 목록을 주입하기 위한 자동화 구간입니다.
 <!--START_GITHUB_PAGES-->
-- (자동 갱신 준비 중입니다.)
+- (데이터를 불러오지 못했습니다.)
 <!--END_GITHUB_PAGES-->
 
 ### Velog
 > 💡 `<!--START_VELOG-->` / `<!--END_VELOG-->` 마커 역시 Velog 최신 글을 자동으로 삽입하기 위한 영역입니다.
 <!--START_VELOG-->
-- (자동 갱신 준비 중입니다.)
+- (데이터를 불러오지 못했습니다.)
 <!--END_VELOG-->
 
 > 위 목록은 GitHub Actions로 매일 자동 갱신됩니다.


### PR DESCRIPTION
## Summary
- update the README automation script to search for start/end markers at the beginning of lines so inline mentions do not break updates
- treat placeholder content as empty so the workflow can write a fallback message when feeds are unreachable and log that behavior
- refresh the README placeholders to show a failure notice when feeds cannot be fetched

## Testing
- npm run update:readme

------
https://chatgpt.com/codex/tasks/task_e_69030d5025c08331bbd8da0b821b0075