### PR TITLE
Run README update workflow on push events

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -4,9 +4,13 @@ on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
+  push:
+    branches:
+      - main
 
 jobs:
   update-readme:
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- trigger the README update workflow when commits are pushed to main
- prevent reruns when the workflow's auto-commit action pushes updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69030f36c7a48331a7c9064b4d6fd1d4