### PR TITLE
Align profile with product engineering signals

### DIFF
--- a/.github/workflows/update-projects.yml
+++ b/.github/workflows/update-projects.yml
@@ -21,10 +21,10 @@ jobs:
       
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: '24'
         cache: 'npm'
@@ -33,6 +33,11 @@ jobs:
       run: |
         cd ${{ github.workspace }}
         npm ci
+
+    - name: Test profile generator
+      run: |
+        cd ${{ github.workspace }}
+        npm test
         
     - name: Update profile content
       run: |

--- a/README.md
+++ b/README.md
@@ -3,39 +3,49 @@
   <source media="(prefers-color-scheme: light) and (max-width: 600px)" srcset="./assets/profile-light-mobile.svg">
   <source media="(prefers-color-scheme: dark)" srcset="./assets/profile-dark.svg">
   <source media="(prefers-color-scheme: light)" srcset="./assets/profile-light.svg">
-  <img src="./assets/profile-light.svg" alt="uiwwsw frontend engineering profile: Ship the product. Make the next change easier." width="100%">
+  <img src="./assets/profile-light.svg" alt="uiwwsw frontend product engineering profile: Complex products. Clear systems." width="100%">
 </picture>
 
 <p align="center">
-  <strong>제품을 출시하고, 다음 변경이 쉬워지는 구조를 남깁니다.</strong><br>
-  <sub>UI에서 시작해 제품 구축, 운영, 마이그레이션, 아키텍처와 팀 표준까지 이어 왔습니다.</sub>
+  <strong>복잡한 제품을 사용자에게는 단순하게, 팀에게는 계속 바꿀 수 있게 만듭니다.</strong><br>
+  <sub>신규 구축과 운영, 점진적 마이그레이션, 공통 규약과 코드리뷰 기준까지 제품의 전 수명주기를 다뤄왔습니다.</sub>
 </p>
 
 <p align="center">
   <samp><a href="mailto:uiwwsw@icloud.com">EMAIL</a> &nbsp;·&nbsp; <a href="https://www.linkedin.com/in/uiwwsw/">LINKEDIN</a> &nbsp;·&nbsp; <a href="https://velog.io/@uiwwsw">TECH LOG</a> &nbsp;·&nbsp; <a href="https://uiwwsw.github.io/">WRITING UNIVERSE</a> &nbsp;·&nbsp; <a href="https://brewstar-code.github.io/">PRODUCTS</a> &nbsp;·&nbsp; <a href="https://githubprint.vercel.app/showcase">RESUME</a></samp>
 </p>
 
+## Product Engineering
+
+- 신규 구축부터 출시, 운영, 리뉴얼까지 제품의 전체 수명주기를 다뤄왔습니다.
+- 레거시를 멈춰 세우지 않고 점진적으로 옮기며, 복잡한 도메인은 경계와 규약으로 단순화합니다.
+- 공통 타입, API 규약, UI 자산, 모노레포와 코드리뷰 기준을 남겨 팀의 변경 비용을 낮춥니다.
+- AI가 만든 초안, 브라우저 예외, 실패 상태를 스키마·테스트·재현 가능한 시나리오로 검증합니다.
+
+<sub>WORKING SET</sub><br>
+<samp>React · TypeScript · Next.js · SvelteKit · TanStack Query · Node.js · Monorepo · GitHub Actions</samp>
+
 ## Selected Work
 
 ### [GitHubPrint](https://githubprint.vercel.app)
-<sub>LIVE PRODUCT · <a href="https://github.com/uiwwsw/githubprint">source</a></sub>
+<sub>PRODUCT / AI RELIABILITY / DOCUMENT EXPORT · <a href="https://github.com/uiwwsw/githubprint">source</a></sub>
 
-Public GitHub evidence into a shareable developer document, with validated AI output, deterministic fallback, and PDF/Word export.
+공개 GitHub 데이터를 근거로 개발자 문서를 생성합니다. AI 출력은 스키마로 검증하고, 실패 시 결정론적 분석으로 전환하며, PDF·Word 내보내기까지 제공합니다.
 
 ### [test-mode](https://github.com/uiwwsw/test-mode)
-<sub>OPEN-SOURCE TOOL</sub>
+<sub>TESTABILITY / API SCENARIOS / COLLABORATION</sub>
 
-Named API scenarios make loading, failure, and edge states reproducible across browser and server boundaries.
+API 성공·지연·실패 상태를 이름 있는 시나리오로 만들어 브라우저와 서버 경계에서 재현합니다. 개발·QA·디자인이 같은 상태를 공유하게 합니다.
 
 ### [virtual-keyboard](https://www.npmjs.com/package/@uiwwsw/virtual-keyboard)
-<sub>NPM PACKAGE · <a href="https://github.com/uiwwsw/virtual-keyboard">source</a></sub>
+<sub>BROWSER INTERNALS / HANGUL INPUT / REACT · <a href="https://github.com/uiwwsw/virtual-keyboard">source</a></sub>
 
-A controlled React keyboard that owns Hangul composition instead of patching native IME symptoms.
+네이티브 IME 이벤트를 덧대는 대신 한글 조합 상태를 입력 모델이 직접 소유하도록 설계한 React 패키지입니다.
 
 ### [react-query-helper](https://www.npmjs.com/package/@uiwwsw/react-query-helper)
-<sub>NPM PACKAGE · <a href="https://github.com/uiwwsw/react-query-helper">source</a></sub>
+<sub>ABSTRACTION / CODE GENERATION / DX · <a href="https://github.com/uiwwsw/react-query-helper">source</a></sub>
 
-A TypeScript CLI that turns API functions into consistent query, mutation, and infinite-query options.
+TypeScript API 함수를 분석해 query·mutation·infinite query 옵션을 생성하고, 반복되는 규약을 코드로 고정합니다.
 
 ## Independent Products
 

--- a/assets/profile-dark-mobile.svg
+++ b/assets/profile-dark-mobile.svg
@@ -1,37 +1,47 @@
-<svg width="720" height="720" viewBox="0 0 720 720" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
-  <title id="title">uiwwsw frontend engineering profile</title>
-  <desc id="desc">Ship the product. Make the next change easier. A career arc from UI craft to product and engineering standards.</desc>
+<svg width="720" height="780" viewBox="0 0 720 780" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">uiwwsw frontend product engineering profile</title>
+  <desc id="desc">Complex products. Clear systems. Simple for users and changeable for teams.</desc>
 
-  <rect width="720" height="720" fill="#0D1117"/>
-  <rect x="0" y="0" width="12" height="720" fill="#FF6B57"/>
+  <rect width="720" height="780" fill="#0D1117"/>
+  <rect width="12" height="780" fill="#FF6B57"/>
 
   <g font-family="Arial, Helvetica, sans-serif">
     <text x="48" y="58" fill="#F0F3F6" font-size="20" font-weight="700">UIWWSW</text>
-    <text x="672" y="58" fill="#7D8590" font-size="16" text-anchor="end">FRONTEND ENGINEERING</text>
+    <text x="672" y="58" fill="#7D8590" font-size="16" text-anchor="end">FRONTEND PRODUCT ENGINEERING</text>
     <rect x="48" y="84" width="624" height="1" fill="#30363D"/>
 
-    <text x="48" y="130" fill="#56D4C0" font-size="17" font-weight="700">BUILD / RELEASE / IMPROVE</text>
-    <text x="48" y="224" fill="#F0F3F6" font-family="Georgia, Times New Roman, serif" font-size="76" font-weight="700">Ship the</text>
-    <text x="48" y="306" fill="#F0F3F6" font-family="Georgia, Times New Roman, serif" font-size="76" font-weight="700">product.</text>
-    <text x="48" y="376" fill="#F0F3F6" font-size="53" font-weight="700">Make the next</text>
-    <text x="48" y="438" fill="#F0F3F6" font-size="53" font-weight="700">change easier.</text>
+    <text x="48" y="130" fill="#56D4C0" font-size="17" font-weight="700">PRODUCT CLARITY / SYSTEM CHANGEABILITY</text>
+    <text x="48" y="222" fill="#F0F3F6" font-family="Georgia, Times New Roman, serif" font-size="70" font-weight="700">Complex</text>
+    <text x="48" y="298" fill="#F0F3F6" font-family="Georgia, Times New Roman, serif" font-size="70" font-weight="700">products.</text>
+    <text x="48" y="368" fill="#F0F3F6" font-size="58" font-weight="700">Clear systems.</text>
+    <text x="50" y="412" fill="#9DA7B2" font-size="22">Simple for users. Changeable for teams.</text>
 
-    <rect x="48" y="476" width="174" height="5" fill="#FF6B57"/>
-    <rect x="222" y="476" width="150" height="5" fill="#E3B341"/>
-    <rect x="372" y="476" width="300" height="5" fill="#56D4C0"/>
+    <rect x="48" y="454" width="624" height="1" fill="#30363D"/>
 
-    <text x="48" y="534" fill="#7AA2F7" font-size="19" font-weight="700">UI CRAFT</text>
-    <text x="160" y="534" fill="#484F58" font-size="19">→</text>
-    <text x="196" y="534" fill="#C9D1D9" font-size="19" font-weight="700">PRODUCT FRONTEND</text>
+    <text x="48" y="504" fill="#FF6B57" font-size="16" font-weight="700">01</text>
+    <text x="92" y="504" fill="#7D8590" font-size="16" font-weight="700">USER</text>
+    <text x="672" y="504" fill="#F0F3F6" font-size="20" font-weight="700" text-anchor="end">CLARITY</text>
 
-    <text x="48" y="580" fill="#C9D1D9" font-size="19" font-weight="700">OWNERSHIP</text>
-    <text x="177" y="580" fill="#484F58" font-size="19">→</text>
-    <text x="213" y="580" fill="#C9D1D9" font-size="19" font-weight="700">MIGRATION</text>
+    <text x="48" y="558" fill="#E3B341" font-size="16" font-weight="700">02</text>
+    <text x="92" y="558" fill="#7D8590" font-size="16" font-weight="700">CODEBASE</text>
+    <text x="672" y="558" fill="#F0F3F6" font-size="20" font-weight="700" text-anchor="end">CHANGEABILITY</text>
 
-    <text x="48" y="626" fill="#C9D1D9" font-size="19" font-weight="700">ARCHITECTURE</text>
-    <text x="216" y="626" fill="#484F58" font-size="19">→</text>
-    <text x="252" y="626" fill="#C9D1D9" font-size="19" font-weight="700">TEAM STANDARDS</text>
+    <text x="48" y="612" fill="#7AA2F7" font-size="16" font-weight="700">03</text>
+    <text x="92" y="612" fill="#7D8590" font-size="16" font-weight="700">TEAM</text>
+    <text x="672" y="612" fill="#F0F3F6" font-size="20" font-weight="700" text-anchor="end">SHARED STANDARDS</text>
 
-    <text x="48" y="680" fill="#7D8590" font-size="15">THE THROUGHLINE, NOT THE TITLE</text>
+    <rect x="48" y="650" width="172" height="5" fill="#FF6B57"/>
+    <rect x="220" y="650" width="152" height="5" fill="#E3B341"/>
+    <rect x="372" y="650" width="300" height="5" fill="#56D4C0"/>
+
+    <text x="48" y="704" fill="#C9D1D9" font-size="17" font-weight="700">BUILD</text>
+    <text x="112" y="704" fill="#484F58" font-size="17">→</text>
+    <text x="148" y="704" fill="#C9D1D9" font-size="17" font-weight="700">OPERATE</text>
+    <text x="244" y="704" fill="#484F58" font-size="17">→</text>
+    <text x="280" y="704" fill="#C9D1D9" font-size="17" font-weight="700">MIGRATE</text>
+    <text x="372" y="704" fill="#484F58" font-size="17">→</text>
+    <text x="408" y="704" fill="#C9D1D9" font-size="17" font-weight="700">SHARE</text>
+
+    <text x="48" y="752" fill="#7D8590" font-size="14">REACT / TYPESCRIPT / PRODUCT DELIVERY</text>
   </g>
 </svg>

--- a/assets/profile-dark.svg
+++ b/assets/profile-dark.svg
@@ -1,38 +1,54 @@
-<svg width="1280" height="460" viewBox="0 0 1280 460" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
-  <title id="title">uiwwsw frontend engineering profile</title>
-  <desc id="desc">Ship the product. Make the next change easier. A career arc from UI craft to product and engineering standards.</desc>
+<svg width="1280" height="500" viewBox="0 0 1280 500" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">uiwwsw frontend product engineering profile</title>
+  <desc id="desc">Complex products. Clear systems. Simple for users and changeable for teams.</desc>
 
-  <rect width="1280" height="460" fill="#0D1117"/>
-  <rect x="0" y="0" width="14" height="460" fill="#FF6B57"/>
+  <rect width="1280" height="500" fill="#0D1117"/>
+  <rect width="14" height="500" fill="#FF6B57"/>
 
   <g font-family="Arial, Helvetica, sans-serif">
     <text x="64" y="58" fill="#F0F3F6" font-size="18" font-weight="700">UIWWSW</text>
-    <text x="155" y="58" fill="#7D8590" font-size="18">/ FRONTEND ENGINEERING</text>
-    <text x="1216" y="58" fill="#7D8590" font-size="14" text-anchor="end">PRODUCT · SYSTEM · CRAFT</text>
-
+    <text x="155" y="58" fill="#7D8590" font-size="18">/ FRONTEND PRODUCT ENGINEERING</text>
+    <text x="1216" y="58" fill="#7D8590" font-size="14" text-anchor="end">REACT · TYPESCRIPT · AI-AUGMENTED</text>
     <rect x="64" y="84" width="1152" height="1" fill="#30363D"/>
-    <text x="64" y="128" fill="#56D4C0" font-size="14" font-weight="700">BUILD / RELEASE / IMPROVE</text>
 
-    <text x="64" y="222" fill="#F0F3F6" font-family="Georgia, Times New Roman, serif" font-size="86" font-weight="700">Ship the product.</text>
-    <text x="64" y="302" fill="#F0F3F6" font-size="66" font-weight="700">Make the next change easier.</text>
+    <text x="64" y="130" fill="#56D4C0" font-size="14" font-weight="700">PRODUCT CLARITY / SYSTEM CHANGEABILITY</text>
+    <text x="64" y="218" fill="#F0F3F6" font-family="Georgia, Times New Roman, serif" font-size="82" font-weight="700">Complex products.</text>
+    <text x="64" y="296" fill="#F0F3F6" font-size="70" font-weight="700">Clear systems.</text>
+    <text x="68" y="342" fill="#9DA7B2" font-size="22">Simple for users. Changeable for teams.</text>
 
-    <rect x="64" y="336" width="326" height="5" fill="#FF6B57"/>
-    <rect x="390" y="336" width="278" height="5" fill="#E3B341"/>
-    <rect x="668" y="336" width="548" height="5" fill="#56D4C0"/>
+    <rect x="840" y="116" width="1" height="236" fill="#30363D"/>
 
-    <text x="64" y="390" fill="#7AA2F7" font-size="14" font-weight="700">UI CRAFT</text>
-    <text x="166" y="390" fill="#484F58" font-size="14">→</text>
-    <text x="198" y="390" fill="#C9D1D9" font-size="14" font-weight="700">PRODUCT FRONTEND</text>
-    <text x="366" y="390" fill="#484F58" font-size="14">→</text>
-    <text x="398" y="390" fill="#C9D1D9" font-size="14" font-weight="700">OWNERSHIP</text>
-    <text x="505" y="390" fill="#484F58" font-size="14">→</text>
-    <text x="537" y="390" fill="#C9D1D9" font-size="14" font-weight="700">MIGRATION</text>
-    <text x="641" y="390" fill="#484F58" font-size="14">→</text>
-    <text x="673" y="390" fill="#C9D1D9" font-size="14" font-weight="700">ARCHITECTURE</text>
-    <text x="808" y="390" fill="#484F58" font-size="14">→</text>
-    <text x="840" y="390" fill="#C9D1D9" font-size="14" font-weight="700">TEAM STANDARDS</text>
+    <text x="884" y="154" fill="#FF6B57" font-size="14" font-weight="700">01</text>
+    <text x="928" y="154" fill="#7D8590" font-size="14" font-weight="700">USER</text>
+    <text x="1216" y="154" fill="#F0F3F6" font-size="18" font-weight="700" text-anchor="end">CLARITY</text>
+    <rect x="884" y="180" width="332" height="1" fill="#252B32"/>
 
-    <text x="64" y="426" fill="#7D8590" font-size="13">THE THROUGHLINE, NOT THE TITLE</text>
-    <text x="1216" y="426" fill="#7D8590" font-size="13" text-anchor="end">REACT / TYPESCRIPT / PRODUCT DELIVERY</text>
+    <text x="884" y="226" fill="#E3B341" font-size="14" font-weight="700">02</text>
+    <text x="928" y="226" fill="#7D8590" font-size="14" font-weight="700">CODEBASE</text>
+    <text x="1216" y="226" fill="#F0F3F6" font-size="18" font-weight="700" text-anchor="end">CHANGEABILITY</text>
+    <rect x="884" y="252" width="332" height="1" fill="#252B32"/>
+
+    <text x="884" y="298" fill="#7AA2F7" font-size="14" font-weight="700">03</text>
+    <text x="928" y="298" fill="#7D8590" font-size="14" font-weight="700">TEAM</text>
+    <text x="1216" y="298" fill="#F0F3F6" font-size="18" font-weight="700" text-anchor="end">SHARED STANDARDS</text>
+
+    <rect x="64" y="386" width="294" height="5" fill="#FF6B57"/>
+    <rect x="358" y="386" width="288" height="5" fill="#E3B341"/>
+    <rect x="646" y="386" width="570" height="5" fill="#56D4C0"/>
+
+    <text x="64" y="435" fill="#C9D1D9" font-size="14" font-weight="700">DISCOVER</text>
+    <text x="161" y="435" fill="#484F58" font-size="14">→</text>
+    <text x="193" y="435" fill="#C9D1D9" font-size="14" font-weight="700">ABSTRACT</text>
+    <text x="294" y="435" fill="#484F58" font-size="14">→</text>
+    <text x="326" y="435" fill="#C9D1D9" font-size="14" font-weight="700">BUILD</text>
+    <text x="391" y="435" fill="#484F58" font-size="14">→</text>
+    <text x="423" y="435" fill="#C9D1D9" font-size="14" font-weight="700">OPERATE</text>
+    <text x="510" y="435" fill="#484F58" font-size="14">→</text>
+    <text x="542" y="435" fill="#C9D1D9" font-size="14" font-weight="700">MIGRATE</text>
+    <text x="627" y="435" fill="#484F58" font-size="14">→</text>
+    <text x="659" y="435" fill="#C9D1D9" font-size="14" font-weight="700">SHARE</text>
+
+    <text x="64" y="470" fill="#7D8590" font-size="13">PRODUCT DELIVERY / ARCHITECTURE / DEVELOPER EXPERIENCE</text>
+    <text x="1216" y="470" fill="#7D8590" font-size="13" text-anchor="end">BUILD · OPERATE · IMPROVE</text>
   </g>
 </svg>

--- a/assets/profile-light-mobile.svg
+++ b/assets/profile-light-mobile.svg
@@ -1,37 +1,47 @@
-<svg width="720" height="720" viewBox="0 0 720 720" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
-  <title id="title">uiwwsw frontend engineering profile</title>
-  <desc id="desc">Ship the product. Make the next change easier. A career arc from UI craft to product and engineering standards.</desc>
+<svg width="720" height="780" viewBox="0 0 720 780" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">uiwwsw frontend product engineering profile</title>
+  <desc id="desc">Complex products. Clear systems. Simple for users and changeable for teams.</desc>
 
-  <rect width="720" height="720" fill="#F6F8FA"/>
-  <rect x="0" y="0" width="12" height="720" fill="#D94C3D"/>
+  <rect width="720" height="780" fill="#F6F8FA"/>
+  <rect width="12" height="780" fill="#D94C3D"/>
 
   <g font-family="Arial, Helvetica, sans-serif">
     <text x="48" y="58" fill="#1F2328" font-size="20" font-weight="700">UIWWSW</text>
-    <text x="672" y="58" fill="#656D76" font-size="16" text-anchor="end">FRONTEND ENGINEERING</text>
+    <text x="672" y="58" fill="#656D76" font-size="16" text-anchor="end">FRONTEND PRODUCT ENGINEERING</text>
     <rect x="48" y="84" width="624" height="1" fill="#D0D7DE"/>
 
-    <text x="48" y="130" fill="#16856F" font-size="17" font-weight="700">BUILD / RELEASE / IMPROVE</text>
-    <text x="48" y="224" fill="#1F2328" font-family="Georgia, Times New Roman, serif" font-size="76" font-weight="700">Ship the</text>
-    <text x="48" y="306" fill="#1F2328" font-family="Georgia, Times New Roman, serif" font-size="76" font-weight="700">product.</text>
-    <text x="48" y="376" fill="#1F2328" font-size="53" font-weight="700">Make the next</text>
-    <text x="48" y="438" fill="#1F2328" font-size="53" font-weight="700">change easier.</text>
+    <text x="48" y="130" fill="#16856F" font-size="17" font-weight="700">PRODUCT CLARITY / SYSTEM CHANGEABILITY</text>
+    <text x="48" y="222" fill="#1F2328" font-family="Georgia, Times New Roman, serif" font-size="70" font-weight="700">Complex</text>
+    <text x="48" y="298" fill="#1F2328" font-family="Georgia, Times New Roman, serif" font-size="70" font-weight="700">products.</text>
+    <text x="48" y="368" fill="#1F2328" font-size="58" font-weight="700">Clear systems.</text>
+    <text x="50" y="412" fill="#656D76" font-size="22">Simple for users. Changeable for teams.</text>
 
-    <rect x="48" y="476" width="174" height="5" fill="#D94C3D"/>
-    <rect x="222" y="476" width="150" height="5" fill="#9A6700"/>
-    <rect x="372" y="476" width="300" height="5" fill="#16856F"/>
+    <rect x="48" y="454" width="624" height="1" fill="#D0D7DE"/>
 
-    <text x="48" y="534" fill="#315DCE" font-size="19" font-weight="700">UI CRAFT</text>
-    <text x="160" y="534" fill="#8C959F" font-size="19">→</text>
-    <text x="196" y="534" fill="#424A53" font-size="19" font-weight="700">PRODUCT FRONTEND</text>
+    <text x="48" y="504" fill="#D94C3D" font-size="16" font-weight="700">01</text>
+    <text x="92" y="504" fill="#656D76" font-size="16" font-weight="700">USER</text>
+    <text x="672" y="504" fill="#1F2328" font-size="20" font-weight="700" text-anchor="end">CLARITY</text>
 
-    <text x="48" y="580" fill="#424A53" font-size="19" font-weight="700">OWNERSHIP</text>
-    <text x="177" y="580" fill="#8C959F" font-size="19">→</text>
-    <text x="213" y="580" fill="#424A53" font-size="19" font-weight="700">MIGRATION</text>
+    <text x="48" y="558" fill="#9A6700" font-size="16" font-weight="700">02</text>
+    <text x="92" y="558" fill="#656D76" font-size="16" font-weight="700">CODEBASE</text>
+    <text x="672" y="558" fill="#1F2328" font-size="20" font-weight="700" text-anchor="end">CHANGEABILITY</text>
 
-    <text x="48" y="626" fill="#424A53" font-size="19" font-weight="700">ARCHITECTURE</text>
-    <text x="216" y="626" fill="#8C959F" font-size="19">→</text>
-    <text x="252" y="626" fill="#424A53" font-size="19" font-weight="700">TEAM STANDARDS</text>
+    <text x="48" y="612" fill="#315DCE" font-size="16" font-weight="700">03</text>
+    <text x="92" y="612" fill="#656D76" font-size="16" font-weight="700">TEAM</text>
+    <text x="672" y="612" fill="#1F2328" font-size="20" font-weight="700" text-anchor="end">SHARED STANDARDS</text>
 
-    <text x="48" y="680" fill="#656D76" font-size="15">THE THROUGHLINE, NOT THE TITLE</text>
+    <rect x="48" y="650" width="172" height="5" fill="#D94C3D"/>
+    <rect x="220" y="650" width="152" height="5" fill="#9A6700"/>
+    <rect x="372" y="650" width="300" height="5" fill="#16856F"/>
+
+    <text x="48" y="704" fill="#424A53" font-size="17" font-weight="700">BUILD</text>
+    <text x="112" y="704" fill="#8C959F" font-size="17">→</text>
+    <text x="148" y="704" fill="#424A53" font-size="17" font-weight="700">OPERATE</text>
+    <text x="244" y="704" fill="#8C959F" font-size="17">→</text>
+    <text x="280" y="704" fill="#424A53" font-size="17" font-weight="700">MIGRATE</text>
+    <text x="372" y="704" fill="#8C959F" font-size="17">→</text>
+    <text x="408" y="704" fill="#424A53" font-size="17" font-weight="700">SHARE</text>
+
+    <text x="48" y="752" fill="#656D76" font-size="14">REACT / TYPESCRIPT / PRODUCT DELIVERY</text>
   </g>
 </svg>

--- a/assets/profile-light.svg
+++ b/assets/profile-light.svg
@@ -1,38 +1,54 @@
-<svg width="1280" height="460" viewBox="0 0 1280 460" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
-  <title id="title">uiwwsw frontend engineering profile</title>
-  <desc id="desc">Ship the product. Make the next change easier. A career arc from UI craft to product and engineering standards.</desc>
+<svg width="1280" height="500" viewBox="0 0 1280 500" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">uiwwsw frontend product engineering profile</title>
+  <desc id="desc">Complex products. Clear systems. Simple for users and changeable for teams.</desc>
 
-  <rect width="1280" height="460" fill="#F6F8FA"/>
-  <rect x="0" y="0" width="14" height="460" fill="#D94C3D"/>
+  <rect width="1280" height="500" fill="#F6F8FA"/>
+  <rect width="14" height="500" fill="#D94C3D"/>
 
   <g font-family="Arial, Helvetica, sans-serif">
     <text x="64" y="58" fill="#1F2328" font-size="18" font-weight="700">UIWWSW</text>
-    <text x="155" y="58" fill="#656D76" font-size="18">/ FRONTEND ENGINEERING</text>
-    <text x="1216" y="58" fill="#656D76" font-size="14" text-anchor="end">PRODUCT · SYSTEM · CRAFT</text>
-
+    <text x="155" y="58" fill="#656D76" font-size="18">/ FRONTEND PRODUCT ENGINEERING</text>
+    <text x="1216" y="58" fill="#656D76" font-size="14" text-anchor="end">REACT · TYPESCRIPT · AI-AUGMENTED</text>
     <rect x="64" y="84" width="1152" height="1" fill="#D0D7DE"/>
-    <text x="64" y="128" fill="#16856F" font-size="14" font-weight="700">BUILD / RELEASE / IMPROVE</text>
 
-    <text x="64" y="222" fill="#1F2328" font-family="Georgia, Times New Roman, serif" font-size="86" font-weight="700">Ship the product.</text>
-    <text x="64" y="302" fill="#1F2328" font-size="66" font-weight="700">Make the next change easier.</text>
+    <text x="64" y="130" fill="#16856F" font-size="14" font-weight="700">PRODUCT CLARITY / SYSTEM CHANGEABILITY</text>
+    <text x="64" y="218" fill="#1F2328" font-family="Georgia, Times New Roman, serif" font-size="82" font-weight="700">Complex products.</text>
+    <text x="64" y="296" fill="#1F2328" font-size="70" font-weight="700">Clear systems.</text>
+    <text x="68" y="342" fill="#656D76" font-size="22">Simple for users. Changeable for teams.</text>
 
-    <rect x="64" y="336" width="326" height="5" fill="#D94C3D"/>
-    <rect x="390" y="336" width="278" height="5" fill="#9A6700"/>
-    <rect x="668" y="336" width="548" height="5" fill="#16856F"/>
+    <rect x="840" y="116" width="1" height="236" fill="#D0D7DE"/>
 
-    <text x="64" y="390" fill="#315DCE" font-size="14" font-weight="700">UI CRAFT</text>
-    <text x="166" y="390" fill="#8C959F" font-size="14">→</text>
-    <text x="198" y="390" fill="#424A53" font-size="14" font-weight="700">PRODUCT FRONTEND</text>
-    <text x="366" y="390" fill="#8C959F" font-size="14">→</text>
-    <text x="398" y="390" fill="#424A53" font-size="14" font-weight="700">OWNERSHIP</text>
-    <text x="505" y="390" fill="#8C959F" font-size="14">→</text>
-    <text x="537" y="390" fill="#424A53" font-size="14" font-weight="700">MIGRATION</text>
-    <text x="641" y="390" fill="#8C959F" font-size="14">→</text>
-    <text x="673" y="390" fill="#424A53" font-size="14" font-weight="700">ARCHITECTURE</text>
-    <text x="808" y="390" fill="#8C959F" font-size="14">→</text>
-    <text x="840" y="390" fill="#424A53" font-size="14" font-weight="700">TEAM STANDARDS</text>
+    <text x="884" y="154" fill="#D94C3D" font-size="14" font-weight="700">01</text>
+    <text x="928" y="154" fill="#656D76" font-size="14" font-weight="700">USER</text>
+    <text x="1216" y="154" fill="#1F2328" font-size="18" font-weight="700" text-anchor="end">CLARITY</text>
+    <rect x="884" y="180" width="332" height="1" fill="#D8DEE4"/>
 
-    <text x="64" y="426" fill="#656D76" font-size="13">THE THROUGHLINE, NOT THE TITLE</text>
-    <text x="1216" y="426" fill="#656D76" font-size="13" text-anchor="end">REACT / TYPESCRIPT / PRODUCT DELIVERY</text>
+    <text x="884" y="226" fill="#9A6700" font-size="14" font-weight="700">02</text>
+    <text x="928" y="226" fill="#656D76" font-size="14" font-weight="700">CODEBASE</text>
+    <text x="1216" y="226" fill="#1F2328" font-size="18" font-weight="700" text-anchor="end">CHANGEABILITY</text>
+    <rect x="884" y="252" width="332" height="1" fill="#D8DEE4"/>
+
+    <text x="884" y="298" fill="#315DCE" font-size="14" font-weight="700">03</text>
+    <text x="928" y="298" fill="#656D76" font-size="14" font-weight="700">TEAM</text>
+    <text x="1216" y="298" fill="#1F2328" font-size="18" font-weight="700" text-anchor="end">SHARED STANDARDS</text>
+
+    <rect x="64" y="386" width="294" height="5" fill="#D94C3D"/>
+    <rect x="358" y="386" width="288" height="5" fill="#9A6700"/>
+    <rect x="646" y="386" width="570" height="5" fill="#16856F"/>
+
+    <text x="64" y="435" fill="#424A53" font-size="14" font-weight="700">DISCOVER</text>
+    <text x="161" y="435" fill="#8C959F" font-size="14">→</text>
+    <text x="193" y="435" fill="#424A53" font-size="14" font-weight="700">ABSTRACT</text>
+    <text x="294" y="435" fill="#8C959F" font-size="14">→</text>
+    <text x="326" y="435" fill="#424A53" font-size="14" font-weight="700">BUILD</text>
+    <text x="391" y="435" fill="#8C959F" font-size="14">→</text>
+    <text x="423" y="435" fill="#424A53" font-size="14" font-weight="700">OPERATE</text>
+    <text x="510" y="435" fill="#8C959F" font-size="14">→</text>
+    <text x="542" y="435" fill="#424A53" font-size="14" font-weight="700">MIGRATE</text>
+    <text x="627" y="435" fill="#8C959F" font-size="14">→</text>
+    <text x="659" y="435" fill="#424A53" font-size="14" font-weight="700">SHARE</text>
+
+    <text x="64" y="470" fill="#656D76" font-size="13">PRODUCT DELIVERY / ARCHITECTURE / DEVELOPER EXPERIENCE</text>
+    <text x="1216" y="470" fill="#656D76" font-size="13" text-anchor="end">BUILD · OPERATE · IMPROVE</text>
   </g>
 </svg>

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "test": "node --test scripts/update-projects.test.js",
     "update:projects": "node scripts/update-projects.js"
   },
   "dependencies": {

--- a/scripts/profile-data.js
+++ b/scripts/profile-data.js
@@ -1,8 +1,8 @@
 const PROFILE = {
     identity: {
         handle: 'uiwwsw',
-        headline: '제품을 출시하고, 다음 변경이 쉬워지는 구조를 남깁니다.',
-        careerLine: 'UI에서 시작해 제품 구축, 운영, 마이그레이션, 아키텍처와 팀 표준까지 이어 왔습니다.',
+        headline: '복잡한 제품을 사용자에게는 단순하게, 팀에게는 계속 바꿀 수 있게 만듭니다.',
+        careerLine: '신규 구축과 운영, 점진적 마이그레이션, 공통 규약과 코드리뷰 기준까지 제품의 전 수명주기를 다뤄왔습니다.',
     },
     links: [
         { label: 'EMAIL', href: 'mailto:uiwwsw@icloud.com' },
@@ -12,33 +12,49 @@ const PROFILE = {
         { label: 'PRODUCTS', href: 'https://brewstar-code.github.io/' },
         { label: 'RESUME', href: 'https://githubprint.vercel.app/showcase' },
     ],
+    productEngineering: [
+        '신규 구축부터 출시, 운영, 리뉴얼까지 제품의 전체 수명주기를 다뤄왔습니다.',
+        '레거시를 멈춰 세우지 않고 점진적으로 옮기며, 복잡한 도메인은 경계와 규약으로 단순화합니다.',
+        '공통 타입, API 규약, UI 자산, 모노레포와 코드리뷰 기준을 남겨 팀의 변경 비용을 낮춥니다.',
+        'AI가 만든 초안, 브라우저 예외, 실패 상태를 스키마·테스트·재현 가능한 시나리오로 검증합니다.',
+    ],
+    workingSet: [
+        'React',
+        'TypeScript',
+        'Next.js',
+        'SvelteKit',
+        'TanStack Query',
+        'Node.js',
+        'Monorepo',
+        'GitHub Actions',
+    ],
     selectedWork: [
         {
             label: 'GitHubPrint',
             url: 'https://githubprint.vercel.app',
             sourceUrl: 'https://github.com/uiwwsw/githubprint',
-            kind: 'Live product',
-            description: 'Public GitHub evidence into a shareable developer document, with validated AI output, deterministic fallback, and PDF/Word export.',
+            signals: 'PRODUCT / AI RELIABILITY / DOCUMENT EXPORT',
+            description: '공개 GitHub 데이터를 근거로 개발자 문서를 생성합니다. AI 출력은 스키마로 검증하고, 실패 시 결정론적 분석으로 전환하며, PDF·Word 내보내기까지 제공합니다.',
         },
         {
             label: 'test-mode',
             url: 'https://github.com/uiwwsw/test-mode',
-            kind: 'Open-source tool',
-            description: 'Named API scenarios make loading, failure, and edge states reproducible across browser and server boundaries.',
+            signals: 'TESTABILITY / API SCENARIOS / COLLABORATION',
+            description: 'API 성공·지연·실패 상태를 이름 있는 시나리오로 만들어 브라우저와 서버 경계에서 재현합니다. 개발·QA·디자인이 같은 상태를 공유하게 합니다.',
         },
         {
             label: 'virtual-keyboard',
             url: 'https://www.npmjs.com/package/@uiwwsw/virtual-keyboard',
             sourceUrl: 'https://github.com/uiwwsw/virtual-keyboard',
-            kind: 'npm package',
-            description: 'A controlled React keyboard that owns Hangul composition instead of patching native IME symptoms.',
+            signals: 'BROWSER INTERNALS / HANGUL INPUT / REACT',
+            description: '네이티브 IME 이벤트를 덧대는 대신 한글 조합 상태를 입력 모델이 직접 소유하도록 설계한 React 패키지입니다.',
         },
         {
             label: 'react-query-helper',
             url: 'https://www.npmjs.com/package/@uiwwsw/react-query-helper',
             sourceUrl: 'https://github.com/uiwwsw/react-query-helper',
-            kind: 'npm package',
-            description: 'A TypeScript CLI that turns API functions into consistent query, mutation, and infinite-query options.',
+            signals: 'ABSTRACTION / CODE GENERATION / DX',
+            description: 'TypeScript API 함수를 분석해 query·mutation·infinite query 옵션을 생성하고, 반복되는 규약을 코드로 고정합니다.',
         },
     ],
     productCopy: {

--- a/scripts/update-projects.js
+++ b/scripts/update-projects.js
@@ -110,10 +110,14 @@ function renderSelectedWork(items) {
             ? ` · <a href="${item.sourceUrl}">source</a>`
             : '';
         return `### [${item.label}](${item.url})
-<sub>${item.kind.toUpperCase()}${source}</sub>
+<sub>${item.signals}${source}</sub>
 
 ${item.description}`;
     }).join('\n\n');
+}
+
+function renderProductEngineering(items) {
+    return items.map((item) => `- ${item}`).join('\n');
 }
 
 function renderProducts(products) {
@@ -139,7 +143,7 @@ function buildReadme({ products, velogPosts }) {
   <source media="(prefers-color-scheme: light) and (max-width: 600px)" srcset="./assets/profile-light-mobile.svg">
   <source media="(prefers-color-scheme: dark)" srcset="./assets/profile-dark.svg">
   <source media="(prefers-color-scheme: light)" srcset="./assets/profile-light.svg">
-  <img src="./assets/profile-light.svg" alt="uiwwsw frontend engineering profile: Ship the product. Make the next change easier." width="100%">
+  <img src="./assets/profile-light.svg" alt="uiwwsw frontend product engineering profile: Complex products. Clear systems." width="100%">
 </picture>
 
 <p align="center">
@@ -150,6 +154,13 @@ function buildReadme({ products, velogPosts }) {
 <p align="center">
   <samp>${renderNavigation(PROFILE.links)}</samp>
 </p>
+
+## Product Engineering
+
+${renderProductEngineering(PROFILE.productEngineering)}
+
+<sub>WORKING SET</sub><br>
+<samp>${PROFILE.workingSet.join(' · ')}</samp>
 
 ## Selected Work
 
@@ -291,5 +302,6 @@ module.exports = {
     buildReadme,
     fetchBrewstarProducts,
     fetchLatestVelogPosts,
+    renderProductEngineering,
     updateReadme,
 };

--- a/scripts/update-projects.test.js
+++ b/scripts/update-projects.test.js
@@ -1,0 +1,29 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { PROFILE } = require('./profile-data');
+const { buildReadme, renderProductEngineering } = require('./update-projects');
+
+test('renders the product engineering evidence without inflated titles', () => {
+    const section = renderProductEngineering(PROFILE.productEngineering);
+
+    assert.match(section, /점진적으로 옮기며/);
+    assert.match(section, /코드리뷰 기준/);
+    assert.doesNotMatch(section, /C-Level|CEO|CTO|대표|이사/);
+});
+
+test('builds a theme-aware profile with stable dynamic sections', () => {
+    const readme = buildReadme({
+        products: PROFILE.fallbackProducts,
+        velogPosts: PROFILE.fallbackVelogPosts,
+    });
+
+    assert.match(readme, /profile-dark-mobile\.svg/);
+    assert.match(readme, /## Product Engineering/);
+    assert.match(readme, /## Selected Work/);
+    assert.match(readme, /<!--START_PRODUCTS-->/);
+    assert.match(readme, /<!--START_VELOG-->/);
+
+    for (const project of PROFILE.selectedWork) {
+        assert.match(readme, new RegExp(project.label.replaceAll('-', '\\-')));
+    }
+});


### PR DESCRIPTION
## What changed

- Reframed the profile around product complexity, codebase changeability, and shared team standards.
- Added a concise production-engineering section covering product lifecycle, incremental migration, common contracts, review standards, and validated AI-assisted work.
- Rewrote selected project descriptions in Korean and labeled the engineering signal each project demonstrates.
- Rebuilt dark, light, desktop, and mobile profile artwork around `Complex products. Clear systems.`
- Added deterministic generator tests and runs them in the scheduled profile workflow.
- Updated `actions/checkout` and `actions/setup-node` to their current v7 major releases.

## Why

The previous profile showed good public projects but did not expose the production experience that senior frontend hiring teams evaluate: operating a product through change, simplifying difficult requirements, migrating incrementally, improving team-wide standards, and validating AI-assisted output.

This revision connects those career-backed signals to public evidence without publishing employer details or claiming an inflated title.

## Validation

- `npm ci`
- `npm test`
- `npm run update:projects` with idempotent README output
- `node --check` for profile scripts and tests
- `xmllint --noout` for all profile SVGs
- Rendered and visually inspected all four desktop/mobile dark/light assets
- `npm audit --omit=dev`
- `git diff --check`
